### PR TITLE
Add tooltips for Shape errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [ trunk ]
   pull_request:
     branches: [ trunk ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -589,7 +589,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb P (subst x t Q) then
         []
       else
-        [(ShapeError, (lass, "Kan de correctheid van deze toekenning niet bewijzen; kan het toekenningsaxioma niet toepassen want de pre- en postconditie van de toekenning hebben niet de juiste vorm"))]
+        [(ShapeError, (lass, "Kan de correctheid van deze toekenning niet bewijzen; kan het toekenningsaxioma niet toepassen want de pre- en postconditie van de toekenning hebben niet de juiste vorm$→ assert Q[E/x] # Q met E in plaats van x\n     x = E\n→ assert Q"))]
     )
     ++ check_proof_outline total s
   | Assert laP P _ ;; If li C ((Assert laPthen Pthen _ ;; _) as thenBody) ((Assert laPelse Pelse _ ;; _) as elseBody) ;; (Assert laQ Q _ ;; _) as s =>
@@ -604,21 +604,21 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if ends_with_assert thenBody Q then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de postconditie van de 'then'-tak heeft niet de juiste vorm"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de postconditie van de 'then'-tak heeft niet de juiste vorm$     assert P\n     if C:\n         assert P and C\n         ...\n→     assert Q\n     else:\n         assert P and not C\n         ...\n         assert Q\n     assert Q"))]
     )
     ++
     (
       if term_equivb' Pelse (BinOp li And P (Not li C)) then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'else'-tak heeft niet de juiste vorm"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'else'-tak heeft niet de juiste vorm$     assert P\n     if C:\n         assert P and C\n         ...\n         assert Q\n     else:\n→     assert P and not C\n         ...\n         assert Q\n     assert Q"))]
     )
     ++
     (
       if ends_with_assert elseBody Q then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de postconditie van de 'else'-tak heeft niet de juiste vorm"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de postconditie van de 'else'-tak heeft niet de juiste vorm$     assert P\n     if C:\n         assert P and C\n         ...\n         assert Q\n     else:\n         assert P and not C\n         ...\n→     assert Q\n     assert Q"))]
     )
     ++
     check_proof_outline total thenBody
@@ -656,26 +656,26 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
           if term_equivb' P (BinOp lw And Inv (BinOp lw And C (BinOp lw (Eq TInt) V (Var lw x)))) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de preconditie van het luslichaam heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de preconditie van het luslichaam heeft niet de juiste vorm$     assert I # TOTALE CORRECTHEID\n     while C:\n         oude_variant = V\n→     assert I and C and V == oude_variant\n         ...\n         assert I and 0 <= V < oude_variant\n     assert I and not C"))]
         )
         ++
         (
           if ends_with_assert body1 (BinOp lw And Inv (BinOp lw And (BinOp lw Le (Val lw 0) V) (BinOp lw Le (BinOp lw Add V (Val lw 1)) (Var lw x)))) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm$     assert I # TOTALE CORRECTHEID\n     while C:\n         oude_variant = V\n         assert I and C and V == oude_variant\n         ...\n→     assert I and 0 <= V < oude_variant\n     assert I and not C"))]
         )
         ++
         (
           if term_equivb' Q (BinOp lw And Inv (Not lw C)) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm$     assert I # TOTALE CORRECTHEID\n     while C:\n         oude_variant = V\n         assert I and C and V == oude_variant\n         ...\n         assert I and 0 <= V < oude_variant\n→ assert I and not C"))]
         )
         ++
         check_proof_outline total body0
       | _ =>
-        [(ShapeError, (lw, "Om totale correctheid te bewijzen van deze lus, moet het luslichaam beginnen met een toekenning gevolgd door een 'assert'-opdracht"))]
+        [(ShapeError, (lw, "Om totale correctheid te bewijzen van deze lus, moet het luslichaam beginnen met een toekenning gevolgd door een 'assert'-opdracht$     assert I # TOTALE CORRECTHEID\n     while C:\n→     oude_variant = V\n         assert I and C and V == oude_variant\n         ...\n         assert I and 0 <= V < oude_variant\n     assert I and not C"))]
       end
     else
       match body with
@@ -684,26 +684,26 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
           if term_equivb' P (BinOp laInv And Inv C) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de preconditie van het luslichaam heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de preconditie van het luslichaam heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n→     assert I and C\n         ...\n         assert I\n     assert I and not C"))]
         )
         ++
         (
           if ends_with_assert body Inv then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n→     assert I\n     assert I and not C""))]
         )
         ++
         (
           if term_equivb' Q (BinOp laInv And Inv (Not laInv C)) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm"))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n         assert I\n→ assert I and not C""))]
         )
         ++
         check_proof_outline total body
       | _ =>
-        [(ShapeError, (loc_of_stmt body, "Luslichaam moet beginnen met een 'assert'-opdracht"))]
+        [(ShapeError, (loc_of_stmt body, "Luslichaam moet beginnen met een 'assert'-opdracht$     assert I # PARTIËLE CORRECTHEID\n     while C:\n→     assert I and C\n         ...\n         assert I\n     assert I and not C""))]
       end
     )
     ++
@@ -713,7 +713,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb P Q then
         []
       else
-        [(ShapeError, (laP, "De preconditie van een 'pass-opdracht moet gelijk zijn aan haar postconditie"))]
+        [(ShapeError, (laP, "De preconditie van een 'pass-opdracht moet gelijk zijn aan haar postconditie$→ assert P\n     pass\n     assert P"))]
     )
     ++
     check_proof_outline total s

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -691,19 +691,19 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
           if ends_with_assert body Inv then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n→     assert I\n     assert I and not C""))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van het luslichaam heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n→     assert I\n     assert I and not C"))]
         )
         ++
         (
           if term_equivb' Q (BinOp laInv And Inv (Not laInv C)) then
             []
           else
-            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n         assert I\n→ assert I and not C""))]
+            [(ShapeError, (lw, "Kan de correctheid van deze lus niet bewijzen; kan de regel voor lussen niet toepassen want de postconditie van de lus heeft niet de juiste vorm$     assert I # PARTIËLE CORRECTHEID\n     while C:\n         assert I and C\n         ...\n         assert I\n→ assert I and not C"))]
         )
         ++
         check_proof_outline total body
       | _ =>
-        [(ShapeError, (loc_of_stmt body, "Luslichaam moet beginnen met een 'assert'-opdracht$     assert I # PARTIËLE CORRECTHEID\n     while C:\n→     assert I and C\n         ...\n         assert I\n     assert I and not C""))]
+        [(ShapeError, (loc_of_stmt body, "Luslichaam moet beginnen met een 'assert'-opdracht$     assert I # PARTIËLE CORRECTHEID\n     while C:\n→     assert I and C\n         ...\n         assert I\n     assert I and not C"))]
       end
     )
     ++

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -597,7 +597,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb' Pthen (BinOp li And P C) then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm$    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm$     assert P\n     if C:\n→     assert P and C\n         ...\n         assert Q\n     else:\n         assert P and not C\n         ...\n         assert Q\n     assert Q"))]
     )
     ++
     (

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -597,7 +597,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb' Pthen (BinOp li And P C) then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm$    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
     )
     ++
     (

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -597,7 +597,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb' Pthen (BinOp li And P C) then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm&    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm$    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
     )
     ++
     (

--- a/proof_checker.v
+++ b/proof_checker.v
@@ -597,7 +597,7 @@ Fixpoint check_proof_outline(total: bool)(s: stmt): list (error_type * (loc * st
       if term_equivb' Pthen (BinOp li And P C) then
         []
       else
-        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm$    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
+        [(ShapeError, (li, "Kan de correctheid van deze 'if'-opdracht niet bewijzen; kan de regel voor 'if'-opdrachten niet toepassen want de preconditie van de 'then'-tak heeft niet de juiste vorm&    assert P\n    if C:\n→    assert P and C\n        ...\n        assert Q\n    else:\n        assert P and not C\n        ...\n        assert Q\n    assert Q"))]
     )
     ++
     (

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -2004,8 +2004,9 @@ function checkProofOutline(checkEntailments: boolean, total: boolean, env: Env_,
       justificationErrors.push(errors);
   const allErrors = checkEntailments ? [...shapeErrors, ...justificationErrors] : shapeErrors;
   if (allErrors.length > 0) {
-    const msg = getMsg(allErrors[0]).replaceAll("\\n", "&#13;&#10;").split('$');
-    throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? ("&#8203;"+msg[1]) : "");
+    const msg = getMsg(allErrors[0]).replaceAll("\\n", "\n").split('$');
+    console.log(msg);
+    throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? ("\u200b"+msg[1]) : "");
   }
   nbProofOutlinesChecked++;
 }

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -2005,7 +2005,6 @@ function checkProofOutline(checkEntailments: boolean, total: boolean, env: Env_,
   const allErrors = checkEntailments ? [...shapeErrors, ...justificationErrors] : shapeErrors;
   if (allErrors.length > 0) {
     const msg = getMsg(allErrors[0]).replaceAll("\\n", "\n").split('$');
-    console.log(msg);
     throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? ("\u200b"+msg[1]) : "");
   }
   nbProofOutlinesChecked++;

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1542,7 +1542,7 @@ class AssertStatement extends Statement {
       else {
         await condition.evaluate(env);
         let [v] = pop(1);
-        return v?.toString() ?? "None";
+        return JSON.stringify(v);
       }
     }
     if (!b) {
@@ -3063,9 +3063,9 @@ function addErrorWidget(editor: any, line: number, msg: string) {
   icon.innerHTML = "!";
   icon.className = "lint-error-icon";
   const msgs = msg.replaceAll("\\n", "\n").split('$');
-  widget.appendChild(document.createTextNode(msgs[0]));
+  widget.appendChild(document.createTextNode(msgs[0]+" "));
   if (msgs.length > 1) widget.setAttribute('title', "\u200b"+msgs[1]);
-  var closeButton = widget.appendChild(document.createElement("p"));
+  var closeButton = widget.appendChild(document.createElement("span"));
   closeButton.innerHTML = "❌";
   closeButton.style.cursor = "pointer";
   closeButton.onclick = function(){widget.style.display = "none";};

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -2004,7 +2004,7 @@ function checkProofOutline(checkEntailments: boolean, total: boolean, env: Env_,
       justificationErrors.push(errors);
   const allErrors = checkEntailments ? [...shapeErrors, ...justificationErrors] : shapeErrors;
   if (allErrors.length > 0) {
-    const msg = getMsg(allErrors[0]).split('&');
+    const msg = getMsg(allErrors[0]).replaceAll("\\n", "\n").split('&');
     throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? msg[1] : "");
   }
   nbProofOutlinesChecked++;

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1536,8 +1536,16 @@ class AssertStatement extends Statement {
     await this.condition.evaluate(env);
     await this.breakpoint();
     let [b] = pop(1);
-    if (!b)
-      this.executionError("De bewering is onwaar");
+    function unrollBiCondition(condition: Expression) {
+      if (condition instanceof BinaryOperatorExpression)
+        return unrollBiCondition(condition.leftOperand) + "\n" + condition.operator + "\n" + unrollBiCondition(condition.rightOperand);
+      else
+        return await condition.evaluate(env);
+    }
+    if (!b) {
+      const tooltip = (this.condition instanceof BinaryOperatorExpression) ? "$"+unrollBiCondition(this.condition) : "";
+      this.executionError("De bewering is onwaar"+tooltip);
+    }
   }
 }
 

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1536,14 +1536,14 @@ class AssertStatement extends Statement {
     await this.condition.evaluate(env);
     await this.breakpoint();
     let [b] = pop(1);
-    function unrollBiCondition(condition: Expression) {
+    async function unrollBiCondition(condition: Expression) {
       if (condition instanceof BinaryOperatorExpression)
         return unrollBiCondition(condition.leftOperand) + "\n" + condition.operator + "\n" + unrollBiCondition(condition.rightOperand);
       else
         return await condition.evaluate(env);
     }
     if (!b) {
-      const tooltip = (this.condition instanceof BinaryOperatorExpression) ? "$"+unrollBiCondition(this.condition) : "";
+      const tooltip = (this.condition instanceof BinaryOperatorExpression) ? "$"+await unrollBiCondition(this.condition) : "";
       this.executionError("De bewering is onwaar"+tooltip);
     }
   }

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1536,11 +1536,14 @@ class AssertStatement extends Statement {
     await this.condition.evaluate(env);
     await this.breakpoint();
     let [b] = pop(1);
-    async function unrollBiCondition(condition: Expression) {
+    async function unrollBiCondition(condition: Expression): string {
       if (condition instanceof BinaryOperatorExpression)
         return unrollBiCondition(condition.leftOperand) + "\n" + condition.operator + "\n" + unrollBiCondition(condition.rightOperand);
-      else
-        return await condition.evaluate(env);
+      else {
+        await condition.evaluate(env);
+        let [v] = pop(1);
+        return ""+v;
+      }
     }
     if (!b) {
       const tooltip = (this.condition instanceof BinaryOperatorExpression) ? "$"+await unrollBiCondition(this.condition) : "";

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1536,9 +1536,9 @@ class AssertStatement extends Statement {
     await this.condition.evaluate(env);
     await this.breakpoint();
     let [b] = pop(1);
-    async function unrollBiCondition(condition: Expression): string {
+    async function unrollBiCondition(condition: Expression): Promise<string> {
       if (condition instanceof BinaryOperatorExpression)
-        return unrollBiCondition(condition.leftOperand) + "\n" + condition.operator + "\n" + unrollBiCondition(condition.rightOperand);
+        return await unrollBiCondition(condition.leftOperand) + "\n" + condition.operator + "\n" + await unrollBiCondition(condition.rightOperand);
       else {
         await condition.evaluate(env);
         let [v] = pop(1);

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -1542,7 +1542,7 @@ class AssertStatement extends Statement {
       else {
         await condition.evaluate(env);
         let [v] = pop(1);
-        return ""+v;
+        return v?.toString() ?? "None";
       }
     }
     if (!b) {
@@ -2014,10 +2014,8 @@ function checkProofOutline(checkEntailments: boolean, total: boolean, env: Env_,
     else
       justificationErrors.push(errors);
   const allErrors = checkEntailments ? [...shapeErrors, ...justificationErrors] : shapeErrors;
-  if (allErrors.length > 0) {
-    const msg = getMsg(allErrors[0]).replaceAll("\\n", "\n").split('$');
-    throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? ("\u200b"+msg[1]) : "");
-  }
+  if (allErrors.length > 0)
+    throw new LocError(getLoc(allErrors[0]), getMsg(allErrors[0]));
   nbProofOutlinesChecked++;
 }
 
@@ -2072,7 +2070,7 @@ function mkLocFactory(doc: any) {
 }
 
 class LocError extends Error {
-  constructor(public loc: Loc, public msg: string, public tooltip?: string) {
+  constructor(public loc: Loc, public msg: string) {
     super();
   }
 }
@@ -3059,13 +3057,18 @@ function clearErrorWidgets() {
   errorWidgets = [];
 }
 
-function addErrorWidget(editor: any, line: number, msg: string, tooltip?: string) {
+function addErrorWidget(editor: any, line: number, msg: string) {
   var widget = document.createElement("div");
   var icon = widget.appendChild(document.createElement("span"));
   icon.innerHTML = "!";
   icon.className = "lint-error-icon";
-  widget.appendChild(document.createTextNode(msg));
-  if (tooltip) widget.setAttribute('title', tooltip);
+  const msgs = msg.replaceAll("\\n", "\n").split('$');
+  widget.appendChild(document.createTextNode(msgs[0]));
+  if (msgs.length > 1) widget.setAttribute('title', "\u200b"+msgs[1]);
+  var closeButton = widget.appendChild(document.createElement("p"));
+  closeButton.innerHTML="❌";
+  closeButton.style="cursor: pointer;";
+  closeButton.onclick=function(){widget.style="display: none;"};
   widget.className = "lint-error";
   errorWidgets.push(editor.addLineWidget(line, widget, {coverGutter: false, noHScroll: true}));
 }

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -2004,8 +2004,8 @@ function checkProofOutline(checkEntailments: boolean, total: boolean, env: Env_,
       justificationErrors.push(errors);
   const allErrors = checkEntailments ? [...shapeErrors, ...justificationErrors] : shapeErrors;
   if (allErrors.length > 0) {
-    const msg = getMsg(allErrors[0]).replaceAll("\\n", "\n").split('&');
-    throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? msg[1] : "");
+    const msg = getMsg(allErrors[0]).replaceAll("\\n", "&#13;&#10;").split('$');
+    throw new LocError(getLoc(allErrors[0]), msg[0], msg.length > 1 ? ("&#8203;"+msg[1]) : "");
   }
   nbProofOutlinesChecked++;
 }

--- a/pylearner.ts
+++ b/pylearner.ts
@@ -3066,9 +3066,9 @@ function addErrorWidget(editor: any, line: number, msg: string) {
   widget.appendChild(document.createTextNode(msgs[0]));
   if (msgs.length > 1) widget.setAttribute('title', "\u200b"+msgs[1]);
   var closeButton = widget.appendChild(document.createElement("p"));
-  closeButton.innerHTML="❌";
-  closeButton.style="cursor: pointer;";
-  closeButton.onclick=function(){widget.style="display: none;"};
+  closeButton.innerHTML = "❌";
+  closeButton.style.cursor = "pointer";
+  closeButton.onclick = function(){widget.style.display = "none";};
   widget.className = "lint-error";
   errorWidgets.push(editor.addLineWidget(line, widget, {coverGutter: false, noHScroll: true}));
 }
@@ -3095,10 +3095,10 @@ async function handleError(body: () => Promise<void>) {
           start.ch--;
         }
         errorWidgets.push(editor.markText(start, {line: editor.lastLine()}, {className: "syntax-error"}));
-        addErrorWidget(editor, editor.lastLine(), ex.msg, ex.tooltip);
+        addErrorWidget(editor, editor.lastLine(), ex.msg);
       } else {
         errorWidgets.push(editor.markText(start, end, {className: "syntax-error"}));
-        addErrorWidget(editor, start.line, ex.msg, ex.tooltip);
+        addErrorWidget(editor, start.line, ex.msg);
         editor.scrollIntoView({from: start, to: end}, 50);
       }
     } else {


### PR DESCRIPTION
Since the message of some shape errors are too vague to locate the assert statement containing it, I added tooltips with templates from the cheatsheet and arrows.